### PR TITLE
Fix lost gl context with call to makeCurrent()

### DIFF
--- a/lab7/frag.glsl
+++ b/lab7/frag.glsl
@@ -23,4 +23,5 @@ void main() {
     vec3 diffuse = diffuseColor*dot(N,L);
 
     color_out = vec4(lightIntensity*lightColor*diffuse+ambientColor, 1);
+    color_out = vec4(1);
 }


### PR DESCRIPTION
Apparently makeCurrent() has to be called in any non-gl function that changes the gl data, like mouse or keyboard events.

Also move some of the initialization code around so the MVP matrix doesn't get wonky when resizing the window.